### PR TITLE
chore: bump broadcast sdk to 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/credential-providers": "^3.624.0",
         "@generouted/react-router": "^1.19.5",
         "@heroicons/react": "^2.1.3",
-        "amazon-ivs-web-broadcast": "^1.15.0",
+        "amazon-ivs-web-broadcast": "^1.16.0",
         "axios": "^1.7.2",
         "clsx": "^2.1.1",
         "framer-motion": "^11.2.10",
@@ -2354,9 +2354,10 @@
       }
     },
     "node_modules/amazon-ivs-web-broadcast": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/amazon-ivs-web-broadcast/-/amazon-ivs-web-broadcast-1.15.0.tgz",
-      "integrity": "sha512-iJza5y81GwjEf1b8wt2YZeQq2B3xw79f8vp3MUofiEhE3bXIdPpPpuKPAN5DJHf4152HYtrvV7tOjKjeDv07Fg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/amazon-ivs-web-broadcast/-/amazon-ivs-web-broadcast-1.16.0.tgz",
+      "integrity": "sha512-1AtkKeOZfynmxjwFJwM3rZPt14XqocT16X3KbzLItP+O1JCCIyx4txsGpe8EsWYrozFkqQHbVj/bWLM7ZjU/RQ==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "axios": "0.27.2",
         "bowser": "^2.11.0",
@@ -4614,11 +4615,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@aws-sdk/credential-providers": "^3.624.0",
     "@generouted/react-router": "^1.19.5",
     "@heroicons/react": "^2.1.3",
-    "amazon-ivs-web-broadcast": "^1.15.0",
+    "amazon-ivs-web-broadcast": "^1.16.0",
     "axios": "^1.7.2",
     "clsx": "^2.1.1",
     "framer-motion": "^11.2.10",


### PR DESCRIPTION
*Description of changes:*
Bump IVS broadcast SDK to `1.16.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
